### PR TITLE
similar to HTTPS, but for use of the proxy

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -160,6 +160,17 @@ resource "aws_security_group_rule" "allow_https_outbound" {
   security_group_id = aws_security_group.lc_security_group.id
 }
 
+resource "aws_security_group_rule" "allow_proxy_outbound" {
+  description = "Squid Proxy"
+  type        = "egress"
+  from_port   = 3128
+  to_port     = 3128
+  protocol    = "tcp"
+  cidr_blocks = var.allowed_outbound_proxy_cidr_blocks
+
+  security_group_id = aws_security_group.lc_security_group.id
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # THE CONSUL-SPECIFIC INBOUND/OUTBOUND RULES COME FROM THE CONSUL-SECURITY-GROUP-RULES MODULE
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -38,6 +38,11 @@ variable "allowed_outbound_https_cidr_blocks" {
   type        = list(string)
 }
 
+variable "allowed_outbound_proxy_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow Proxy-HTTP connections from Consul nodes"
+  type        = list(string)
+}
+
 variable "user_data" {
   description = "A User Data script to execute while the server is booting. We recommend passing in a bash script that executes the run-consul script, which should have been installed in the Consul AMI by the install-consul module."
   type        = string


### PR DESCRIPTION
This opens the proxy port on the consul outbound security group so that I can feed it the proxy_vpc_cidr from infra/global...